### PR TITLE
Add RedHat 7 deployment

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,8 +8,10 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - trusty
     - xenial
+  - name: RedHat
+    versions:
+    - 7
   galaxy_tags:
     - Jenkins
     - CI

--- a/tasks/jenkins_install.yml
+++ b/tasks/jenkins_install.yml
@@ -1,6 +1,14 @@
 ---
-- name: Install Jenkins
+- name: Install Jenkins (Debian/Ubuntu)
+  when: ansible_os_family == "Debian"
   apt:
     name: "{{ jenkins_apt_package }}"
+    state: present
+    update_cache: yes
+
+- name: Install Jenkins (RedHat)
+  when: ansible_os_family == "RedHat"
+  yum:
+    name: "{{ jenkins_yum_package }}"
     state: present
     update_cache: yes

--- a/tasks/jenkins_post.yml
+++ b/tasks/jenkins_post.yml
@@ -1,4 +1,14 @@
 ---
+- name: Start Jenkins service
+  systemd:
+    name: jenkins
+    state: started
+    enabled: yes
+
+- name: Wait until initial admin password is appear
+  wait_for:
+    path: /var/lib/jenkins/secrets/initialAdminPassword
+
 - name: Get initial admin password
   shell: cat /var/lib/jenkins/secrets/initialAdminPassword
   register: jenkins_initial_admin_password

--- a/tasks/jenkins_pre.yml
+++ b/tasks/jenkins_pre.yml
@@ -1,8 +1,19 @@
 ---
-- name: Add jenkins repository key
+- name: Add jenkins repository key (Debian/Ubuntu)
+  when: ansible_os_family == "Debian"
   apt_key:
     url: "{{ jenkins_apt_key_url }}"
 
-- name: Add jenkins apt-repository
+- name: Add jenkins apt-repository (Debian/Ubuntu)
+  when: ansible_os_family == "Debian"
   apt_repository:
     repo: "{{ jenkins_apt_repo }}"
+
+- name: Add jenkins yum-repository (RedHat)
+  when: ansible_os_family == "RedHat"
+  yum_repository:
+    name: jenkins-stable
+    description: Jenkins CI Stable
+    baseurl: "{{ jenkins_yum_repo }}"
+    gpgkey: "{{ jenkins_yum_key_url }}"
+    gpgcheck: yes

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+jenkins_yum_package: jenkins
+jenkins_yum_key_url: https://jenkins-ci.org/redhat/jenkins-ci.org.key
+jenkins_yum_repo: http://pkg.jenkins.io/redhat-stable


### PR DESCRIPTION
- Add RedHat 7 conditions when installing
- Update apt conditions to deploy only on Debian dist.
